### PR TITLE
FLUID-5280: Added another unit test.

### DIFF
--- a/src/tests/framework-tests/renderer/html/RendererUtilities-test.html
+++ b/src/tests/framework-tests/renderer/html/RendererUtilities-test.html
@@ -187,6 +187,11 @@
             <div class="flc-fluid5280-sub"></div>
         </div>
 
+        <div id="FLUID-5280_1">
+            <div id="flc-fluid5280_1-main"></div>
+            <div id="flc-fluid5280_1-sub"></div>
+        </div>
+
     </div>
 
     <script>


### PR DESCRIPTION
To demonstrate an issue that the default model value still takes precedent over the relayed value when the change request is fired in component's onReady event.
